### PR TITLE
[Feature] Add Base Power Calculation by Pokémon Weight

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-// Types > Berries
 export * from './core';
 export * from './math';
 export * from './errors';

--- a/src/math/__tests__/moves-weight.spec.ts
+++ b/src/math/__tests__/moves-weight.spec.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  getMoveBasePowerByWeight,
+  getMoveBasePowerByRelativeWeight,
+} from '../moves-weight';
+
+describe('Heavy Slam / Heat Crash damage power', () => {
+  const weights = {
+    emboar: 150,
+    snorlax: 460,
+    jumpluff: 3,
+    arcanine: 155,
+    graveler: 105,
+    hariyama: 253.8,
+  };
+
+  it('returns 40 BP move', () => {
+    expect(
+      getMoveBasePowerByRelativeWeight({
+        user: weights.snorlax,
+        target: weights.hariyama,
+      }),
+    ).toBe(40);
+  });
+
+  it('returns 60 BP move', () => {
+    expect(
+      getMoveBasePowerByRelativeWeight({
+        user: weights.snorlax,
+        target: weights.arcanine,
+      }),
+    ).toBe(60);
+  });
+
+  it('returns 80 BP move', () => {
+    expect(
+      getMoveBasePowerByRelativeWeight({
+        user: weights.snorlax,
+        target: weights.emboar,
+      }),
+    ).toBe(80);
+  });
+
+  it('returns 100 BP move', () => {
+    expect(
+      getMoveBasePowerByRelativeWeight({
+        user: weights.snorlax,
+        target: weights.graveler,
+      }),
+    ).toBe(100);
+  });
+
+  it('returns 120 BP move', () => {
+    expect(
+      getMoveBasePowerByRelativeWeight({
+        user: weights.snorlax,
+        target: weights.jumpluff,
+      }),
+    ).toBe(120);
+  });
+});
+
+describe('Grass Knot / Low kick damage power', () => {
+  const weights = {
+    gastly: 0.1,
+    vulpix: 9.9,
+    kakuna: 10,
+    purrlolin: 10.1,
+    nidorina: 20,
+    staraptor: 24.9,
+    seadra: 25,
+    hitmonlee: 49.8,
+    zweilous: 50,
+    hitmonchan: 50.2,
+    bergmite: 99.5,
+    venusaur: 100,
+    rampardos: 102.5,
+    crustle: 200,
+    scolipede: 200.5,
+  };
+  it('returns 20 BP move', () => {
+    expect(getMoveBasePowerByWeight(weights.gastly)).toBe(20);
+    expect(getMoveBasePowerByWeight(weights.vulpix)).toBe(20);
+  });
+
+  it('returns 40 BP move', () => {
+    expect(getMoveBasePowerByWeight(weights.kakuna)).toBe(40);
+    expect(getMoveBasePowerByWeight(weights.purrlolin)).toBe(40);
+    expect(getMoveBasePowerByWeight(weights.nidorina)).toBe(40);
+    expect(getMoveBasePowerByWeight(weights.staraptor)).toBe(40);
+  });
+
+  it('returns 60 BP move', () => {
+    expect(getMoveBasePowerByWeight(weights.seadra)).toBe(60);
+    expect(getMoveBasePowerByWeight(weights.hitmonlee)).toBe(60);
+  });
+
+  it('returns 80 BP move', () => {
+    expect(getMoveBasePowerByWeight(weights.zweilous)).toBe(80);
+    expect(getMoveBasePowerByWeight(weights.hitmonchan)).toBe(80);
+    expect(getMoveBasePowerByWeight(weights.bergmite)).toBe(80);
+  });
+
+  it('returns 100 BP move', () => {
+    expect(getMoveBasePowerByWeight(weights.venusaur)).toBe(100);
+    expect(getMoveBasePowerByWeight(weights.rampardos)).toBe(100);
+  });
+
+  it('returns 120 BP move', () => {
+    expect(getMoveBasePowerByWeight(weights.crustle)).toBe(120);
+    expect(getMoveBasePowerByWeight(weights.scolipede)).toBe(120);
+  });
+});

--- a/src/math/index.ts
+++ b/src/math/index.ts
@@ -1,3 +1,4 @@
 export * from './stat';
 export * from './constants';
 export * from './catch-combo';
+export * from './moves-weight';

--- a/src/math/moves-weight.ts
+++ b/src/math/moves-weight.ts
@@ -1,0 +1,70 @@
+interface GetMoveBasePowerByRelativeWeightParams {
+  user: number;
+  target: number;
+  minimize?: boolean;
+}
+
+/** Returns the move Base Power (BP) according the weight ratio between two Pokémon.
+ * This formula is used to calculate the BP for moves such as {@link https://bulbapedia.bulbagarden.net/wiki/Heavy_Slam_(move) Heavy Slam} and {@link https://bulbapedia.bulbagarden.net/wiki/Heat_Crash_(move) Heat Crash}.
+ * @param {Object} params - The general parameters used for get move Base Power according weight ratio.
+ * @param {number} params.user - The user Pokémon's weight.
+ * @param {number} params.target - True target Pokémon's weight.
+ * @param {boolean} [params.minimize = false] - If the target Pokémon has used the move {@link https://bulbapedia.bulbagarden.net/wiki/Minimize_(move) Minimize}.
+ * @returns {number} The move BP.
+ */
+export const getMoveBasePowerByRelativeWeight = ({
+  user,
+  target,
+  minimize = false,
+}: GetMoveBasePowerByRelativeWeightParams): number => {
+  const r = getMoveBasePowerByRelativeWeightPriorGenVII(user, target);
+  const minimizeBonus = minimize ? 2 : 1;
+
+  return r * minimizeBonus;
+};
+
+/** Returns the move Base Power (BP) according the weight ratio between two Pokémon prior to Generation VII games.
+ * This formula is used to calculate the BP for moves such as {@link https://bulbapedia.bulbagarden.net/wiki/Heavy_Slam_(move) Heavy Slam} and {@link https://bulbapedia.bulbagarden.net/wiki/Heat_Crash_(move) Heat Crash}.
+ * @param {number} userWeight - The user Pokémon's weight.
+ * @param {number} targetWeight - True target Pokémon's weight.
+ * @returns {number} The move BP.
+ */
+export const getMoveBasePowerByRelativeWeightPriorGenVII = (
+  userWeight: number,
+  targetWeight: number,
+): number => {
+  const r = userWeight / targetWeight;
+  if (r < 2) {
+    return 40;
+  } else if (r >= 2 && r < 3) {
+    return 60;
+  } else if (r >= 3 && r < 4) {
+    return 80;
+  } else if (r >= 4 && r < 5) {
+    return 100;
+  } else {
+    return 120;
+  }
+};
+
+/**
+ * Returns the move Base Power (BP) according the Pokémon weight. This formula is used to calculate the BP for moves such as
+ * {@link https://bulbapedia.bulbagarden.net/wiki/Grass_Knot_(move) Grass Knot} and {@link https://bulbapedia.bulbagarden.net/wiki/Low_Kick_(move) Low kick}.
+ * @param {number} weight - The Pokémon's weight.
+ * @returns {number} The move BP.
+ */
+export const getMoveBasePowerByWeight = (weight: number): number => {
+  if (weight >= 200) {
+    return 120;
+  } else if (weight >= 100 && weight < 200) {
+    return 100;
+  } else if (weight >= 50 && weight < 100) {
+    return 80;
+  } else if (weight >= 25 && weight < 50) {
+    return 60;
+  } else if (weight >= 10 && weight < 25) {
+    return 40;
+  } else {
+    return 20;
+  }
+};


### PR DESCRIPTION
## 🏷️ What type of PR is this? 

- [X] Feature

## 🎯 Description

This PR includes the formula for obtaining the Base Power of weight related moves such as Grass Knot, Heavy Slam, Heat Crash, and Low Kick.

## 📝 Related Tickets & Documents
- N/A

## 🖼️ QA Instructions, Screenshots, Recordings

At terminal, run the unit tests for the new module
```bash
$ npm test moves-weight.spec
```

## 🧪 Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes


## ✅ Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/jaflesch/ts-pokeapi/pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you lint your code locally prior to submission?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
- [x] Does your submission pass tests?
