### PR TITLE
[Fix] PokéAPI Pokémon Type resource tests

### DIFF
--- a/src/core/__tests__/type.spec.ts
+++ b/src/core/__tests__/type.spec.ts
@@ -30,7 +30,7 @@ describe('PokéAPI Pokémon Type resource', () => {
     const result = await api.getAll();
     expect(result).toHaveLength(20);
     expect(getResourceIdFromURL(result[0].url)).toBe(1);
-    expect(getResourceIdFromURL(result[19].url)).toBe(10002);
+    expect(getResourceIdFromURL(result[19].url)).toBe(10001);
   });
 
   it('fetches 3 Pokémon Types, starting at 2nd Pokémon Type', async () => {
@@ -43,7 +43,7 @@ describe('PokéAPI Pokémon Type resource', () => {
   it('retuns the total number of Pokémon Type resources', async () => {
     const count = await api.count();
     expect(count).toBeDefined();
-    expect(count).toBe(20);
+    expect(count).toBe(21);
   });
 
   it('retuns pagination info about Pokémon Type resources', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './core';
 export * from './math';
 export * from './errors';
+export * from './pokemon-type';


### PR DESCRIPTION
## 🏷️ What type of PR is this? 

- [X] Bug

## 🎯 Description

This PR fixes the PokéAPI Pokémon Type resources's tests, since PokéAPI updated its database.

## 📝 Related Tickets & Documents
- N/A

## 🖼️ QA Instructions, Screenshots, Recordings

```bash
npm test -- --testPathPattern=src/core/type.spec
```

## 🧪 Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes


## ✅ Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/jaflesch/ts-pokeapi/pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you lint your code locally prior to submission?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
- [x] Does your submission pass tests?
