### PR TITLE
[Feature] Add Pokémon Showdown text template helper

### DIFF
--- a/src/showdown/__tests__/format.spec.ts
+++ b/src/showdown/__tests__/format.spec.ts
@@ -1,0 +1,466 @@
+import { describe, expect, it } from '@jest/globals';
+import { NatureName, pokeapi } from '../../core';
+import { PokemonTypeName } from '../../pokemon-type';
+import { format } from '../format';
+
+describe('when using showdown format() for Name', () => {
+  const pokemon = format({
+    pokemon: 'Pikachu',
+    moves: ['Thunderbolt'],
+  });
+
+  it('should return a string with Pikachu as Pokémon name', () => {
+    expect(pokemon).toContain('Pikachu');
+  });
+
+  it('should return a string with Pikachu as Pokémon name', async () => {
+    const pokemon = await pokeapi('pokemon-species').get('pikachu');
+    const text = format({
+      pokemon,
+      moves: ['Thunderbolt'],
+    });
+    expect(text).toContain('Pikachu');
+  });
+});
+
+describe('when using showdown format() for Moves', () => {
+  it('should return only one move', async () => {
+    const pokemon = await pokeapi('pokemon-species').get('pikachu');
+    const text = format({
+      pokemon,
+      moves: ['Thunderbolt'],
+    });
+    const split = text.split('-').length - 1;
+    expect(split).toBe(1);
+  });
+
+  it('should return four moves', async () => {
+    const pokemon = await pokeapi('pokemon-species').get('pikachu');
+    const text = format({
+      pokemon,
+      moves: ['Thunderbolt', 'Thunder Wave', 'Nasty Plot', 'Charm'],
+    });
+    const split = text.split('-').length - 1;
+    expect(split).toBe(4);
+  });
+});
+
+describe('when using showdown format() for Nickname', () => {
+  it('should countain the chosen Pokémon nickname', async () => {
+    const pokemon = await pokeapi('pokemon-species').get('pikachu');
+    const text = format({
+      pokemon,
+      nickname: 'Foo',
+      moves: ['Thunder'],
+    });
+    expect(text).toContain('Foo');
+    expect(text).toContain('(Pikachu)');
+  });
+});
+
+describe('when using showdown format() for Gender', () => {
+  const request = pokeapi('pokemon-species').get('pikachu');
+  it('should countain the male symbol', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      gender: 'male',
+      moves: ['Thunder'],
+    });
+    expect(text).toContain('(M)');
+  });
+
+  it('should countain the female symbol', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      gender: 'female',
+      moves: ['Thunder'],
+    });
+    expect(text).toContain('(F)');
+  });
+
+  it('should not countain the any gender symbol if genderless', async () => {
+    const pokemon = await pokeapi('pokemon-species').get('mewtwo');
+    const text = format({
+      pokemon,
+      gender: 'genderless',
+      moves: ['Psytrike'],
+    });
+    expect(text).not.toContain('(M)');
+    expect(text).not.toContain('(F)');
+  });
+
+  it('should not countain the any gender symbol if not data provided', async () => {
+    const pokemon = await pokeapi('pokemon-species').get('pikachu');
+    const text = format({
+      pokemon,
+      moves: ['Thunder'],
+    });
+    expect(text).not.toContain('(M)');
+    expect(text).not.toContain('(F)');
+  });
+});
+
+describe('when using showdown format() for Items', () => {
+  const request = pokeapi('pokemon-species').get('pikachu');
+
+  it('should countain the chosen item if data provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      moves: ['Thunder'],
+      item: 'Light Ball',
+    });
+    expect(text).toContain('@ Light Ball');
+  });
+  it('should not countain any item if data not provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      moves: ['Thunder'],
+    });
+    expect(text).not.toContain('@');
+  });
+});
+
+describe('when using showdown format() for Abilities', () => {
+  const request = pokeapi('pokemon-species').get('pikachu');
+
+  it('should countain the chosen ability if data provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      moves: ['Thunder'],
+      ability: 'Static',
+    });
+    expect(text).toContain('Ability: Static');
+  });
+  it('should not countain any ability if data not provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      moves: ['Thunder'],
+    });
+    expect(text).not.toContain('Ability: Static');
+  });
+});
+
+describe('when using showdown format() for Levels', () => {
+  const request = pokeapi('pokemon-species').get('pikachu');
+
+  it('should countain the chosen level if data provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      level: 15,
+      moves: ['Thunder'],
+    });
+    expect(text).toContain('Level: 15');
+  });
+  it('should default to fallback level value if data not provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      moves: ['Thunder'],
+    });
+    expect(text).toContain('Level: 100');
+  });
+});
+
+describe('when using showdown format() for Shiny Pokémon', () => {
+  const request = pokeapi('pokemon-species').get('pikachu');
+
+  it('should countain the shiny information if data provided', async () => {
+    const pokemon = await request;
+    const textShiny = format({
+      pokemon,
+      shiny: true,
+      moves: ['Thunder'],
+    });
+    expect(textShiny).toContain('Shiny: Yes');
+
+    const textNoShiny = format({
+      pokemon,
+      shiny: false,
+      moves: ['Thunder'],
+    });
+    expect(textNoShiny).toContain('Shiny: No');
+  });
+  it('should not countain any shiny information if data not provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      moves: ['Thunder'],
+    });
+    expect(text).not.toContain('Shiny');
+  });
+});
+
+describe('when using showdown format() for Happiness', () => {
+  const request = pokeapi('pokemon-species').get('pikachu');
+
+  it('should countain the happiness information if data provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      happiness: 128,
+      moves: ['Thunder'],
+    });
+    expect(text).toContain('Happiness: 128');
+  });
+
+  it('should not countain any happiness information if data not provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      moves: ['Thunder'],
+    });
+    expect(text).not.toContain('Happiness');
+  });
+});
+
+describe('when using showdown format() for Tera type', () => {
+  const request = pokeapi('pokemon-species').get('pikachu');
+
+  it('should countain the tera type information if data provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      happiness: 128,
+      tera: PokemonTypeName.WATER,
+      moves: ['Thunder'],
+    });
+    expect(text).toContain(`Tera Type: ${PokemonTypeName.WATER}`);
+  });
+
+  it('should not countain any tera type information if data not provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      moves: ['Thunder'],
+    });
+    expect(text).not.toContain('Tera Type:');
+  });
+});
+
+describe('when using showdown format() for Nature', () => {
+  const request = pokeapi('pokemon-species').get('pikachu');
+
+  it('should countain the nature information if data provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      nature: NatureName.TIMID,
+      moves: ['Thunder'],
+    });
+    expect(text).toContain(`${NatureName.TIMID} Nature`);
+  });
+
+  it('should not countain any nature information if data not provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      moves: ['Thunder'],
+    });
+    expect(text).not.toContain('Nature');
+  });
+});
+
+describe('when using showdown format() for EVs', () => {
+  const request = pokeapi('pokemon-species').get('pikachu');
+
+  it('should countain the EVs information for HP if data provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      evs: {
+        hp: 4,
+      },
+      moves: ['Thunder'],
+    });
+    expect(text).toContain(`4 HP`);
+  });
+
+  it('should countain the EVs information for Attack if data provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      evs: {
+        attack: 120,
+      },
+      moves: ['Thunder'],
+    });
+    expect(text).toContain(`120 Atk`);
+  });
+
+  it('should countain the EVs information for Defense if data provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      evs: {
+        defense: 16,
+      },
+      moves: ['Thunder'],
+    });
+    expect(text).toContain(`16 Def`);
+  });
+
+  it('should countain the EVs information for Special Attack if data provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      evs: {
+        specialAttack: 200,
+      },
+      moves: ['Thunder'],
+    });
+    expect(text).toContain(`200 SpA`);
+  });
+
+  it('should countain the EVs information for Special Defense if data provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      evs: {
+        specialDefense: 8,
+      },
+      moves: ['Thunder'],
+    });
+    expect(text).toContain(`8 SpD`);
+  });
+
+  it('should countain the EVs information for Speed if data provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      evs: {
+        speed: 252,
+      },
+      moves: ['Thunder'],
+    });
+    expect(text).toContain(`252 Spe`);
+  });
+
+  it('should countain the EVs spread if multiple data provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      evs: {
+        hp: 4,
+        specialAttack: 252,
+        speed: 252,
+      },
+      moves: ['Thunder'],
+    });
+    expect(text).toContain(`EVs: 4 HP / 252 SpA / 252 Spe`);
+  });
+
+  it('should not countain any EVs information if data not provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      moves: ['Thunder'],
+    });
+    expect(text).not.toContain('EVs:');
+  });
+});
+
+describe('when using showdown format() for EVs', () => {
+  const request = pokeapi('pokemon-species').get('pikachu');
+
+  it('should countain the IVs information for HP if data provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      ivs: {
+        hp: 3,
+      },
+      moves: ['Thunder'],
+    });
+    expect(text).toContain(`3 HP`);
+  });
+
+  it('should countain the IVs information for Attack if data provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      ivs: {
+        attack: 10,
+      },
+      moves: ['Thunder'],
+    });
+    expect(text).toContain(`10 Atk`);
+  });
+
+  it('should countain the IVs information for Defense if data provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      ivs: {
+        defense: 16,
+      },
+      moves: ['Thunder'],
+    });
+    expect(text).toContain(`16 Def`);
+  });
+
+  it('should countain the IVs information for Special Attack if data provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      ivs: {
+        specialAttack: 30,
+      },
+      moves: ['Thunder'],
+    });
+    expect(text).toContain(`30 SpA`);
+  });
+
+  it('should countain the IVs information for Special Defense if data provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      ivs: {
+        specialDefense: 4,
+      },
+      moves: ['Thunder'],
+    });
+    expect(text).toContain(`4 SpD`);
+  });
+
+  it('should countain the IVs information for Speed if data provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      ivs: {
+        speed: 0,
+      },
+      moves: ['Thunder'],
+    });
+    expect(text).toContain(`0 Spe`);
+  });
+
+  it('should countain the EVs spread if multiple data provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      ivs: {
+        hp: 0,
+        defense: 0,
+        specialDefense: 0,
+      },
+      moves: ['Thunder'],
+    });
+    expect(text).toContain(`IVs: 0 HP / 0 Def / 0 SpD`);
+  });
+
+  it('should not countain any IVs information if data not provided', async () => {
+    const pokemon = await request;
+    const text = format({
+      pokemon,
+      moves: ['Thunder'],
+    });
+    expect(text).not.toContain('IVs:');
+  });
+});

--- a/src/showdown/format.ts
+++ b/src/showdown/format.ts
@@ -1,0 +1,147 @@
+import { NatureName, PokemonSpecie } from '../core';
+import { PokemonTypeName } from '../pokemon-type';
+
+interface FormatParams {
+  pokemon: string | PokemonSpecie;
+  level?: number;
+  gender?: 'male' | 'female' | 'genderless';
+  happiness?: number;
+  shiny?: boolean;
+  tera?: PokemonTypeName;
+  nickname?: string;
+  item?: string;
+  ability?: string;
+  moves: [string, string?, string?, string?];
+  nature?: NatureName;
+  ivs?: {
+    hp?: number;
+    attack?: number;
+    defense?: number;
+    specialAttack?: number;
+    specialDefense?: number;
+    speed?: number;
+  };
+  evs?: {
+    hp?: number;
+    attack?: number;
+    defense?: number;
+    specialAttack?: number;
+    specialDefense?: number;
+    speed?: number;
+  };
+}
+
+export const format = ({
+  pokemon,
+  level = 100,
+  shiny,
+  gender,
+  ivs,
+  evs,
+  tera,
+  item,
+  moves,
+  nature,
+  ability,
+  nickname,
+  happiness,
+}: FormatParams) => {
+  let formatedText = '';
+  let pokemonName = '';
+  if (typeof pokemon === 'object') {
+    pokemonName =
+      pokemon.names.find((n) => n.language.name === 'en')?.name ??
+      pokemon.names[0].name;
+  } else {
+    pokemonName = pokemon;
+  }
+
+  if (nickname) {
+    formatedText += `${nickname} (${pokemonName})`;
+  } else {
+    formatedText += pokemonName;
+  }
+
+  if (gender && gender !== 'genderless') {
+    formatedText += ` (${gender === 'male' ? 'M' : 'F'})`;
+  }
+  if (item) {
+    formatedText += ` @ ${item}`;
+  }
+
+  if (ability) {
+    formatedText += `\nAbility: ${ability}`;
+  }
+
+  if (level) {
+    formatedText += `\nLevel: ${level}`;
+  }
+
+  if (shiny !== undefined) {
+    formatedText += `\nShiny: ${shiny === true ? 'Yes' : 'No'}`;
+  }
+  if (happiness) {
+    formatedText += `\nHappiness: ${happiness}`;
+  }
+  if (tera) {
+    formatedText += `\nTera Type: ${tera}`;
+  }
+
+  const formatedEvs: string[] = [];
+  if (evs) {
+    if (evs.hp !== undefined) {
+      formatedEvs.push(`${evs.hp} HP`);
+    }
+    if (evs.attack !== undefined) {
+      formatedEvs.push(`${evs.attack} Atk`);
+    }
+    if (evs.defense !== undefined) {
+      formatedEvs.push(`${evs.defense} Def`);
+    }
+    if (evs.specialAttack !== undefined) {
+      formatedEvs.push(`${evs.specialAttack} SpA`);
+    }
+    if (evs.specialDefense !== undefined) {
+      formatedEvs.push(`${evs.specialDefense} SpD`);
+    }
+    if (evs.speed !== undefined) {
+      formatedEvs.push(`${evs.speed} Spe`);
+    }
+  }
+  if (formatedEvs.length > 0) {
+    formatedText += `\nEVs: ${formatedEvs.join(' / ')}`;
+  }
+
+  if (nature) {
+    formatedText = `\n${nature} Nature`;
+  }
+
+  const formatedIvs: string[] = [];
+  if (ivs) {
+    if (ivs.hp !== undefined) {
+      formatedIvs.push(`${ivs.hp} HP`);
+    }
+    if (ivs.attack !== undefined) {
+      formatedIvs.push(`${ivs.attack} Atk`);
+    }
+    if (ivs.defense !== undefined) {
+      formatedIvs.push(`${ivs.defense} Def`);
+    }
+    if (ivs.specialAttack !== undefined) {
+      formatedIvs.push(`${ivs.specialAttack} SpA`);
+    }
+    if (ivs.specialDefense !== undefined) {
+      formatedIvs.push(`${ivs.specialDefense} SpD`);
+    }
+    if (ivs.speed !== undefined) {
+      formatedIvs.push(`${ivs.speed} Spe`);
+    }
+  }
+  if (formatedIvs.length > 0) {
+    formatedText += `\nIVs: ${formatedIvs.join(' / ')}`;
+  }
+
+  formatedText += `\n${moves.map((move) => `- ${move}`).join('\n')}`;
+
+  return formatedText;
+};

--- a/src/showdown/index.ts
+++ b/src/showdown/index.ts
@@ -1,0 +1,1 @@
+export * from './format';


### PR DESCRIPTION
## 🏷️ What type of PR is this? 

- [X] Feature

## 🎯 Description

This PR adds `format()` function to create a formatted Pokémon Showdown's text according its template rules.

## 📝 Related Tickets & Documents
- N/A

## 🖼️ QA Instructions, Screenshots, Recordings

```bash
npm run test -- --testPathPattern=src/showdown/__tests__
```

## 🧪 Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes


## ✅ Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/jaflesch/ts-pokeapi/pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you lint your code locally prior to submission?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
- [x] Does your submission pass tests?
